### PR TITLE
(#71)fix/find borad by user nickname auth

### DIFF
--- a/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
@@ -73,7 +73,7 @@ public class BoardController {
     return ResponseEntity.status(HttpStatus.OK).body(EntityModel.of(responseFormat, selfLink));
   }
 
-  @PutMapping("/update/{boardId}")
+  @PutMapping(value = "/update/{boardId}", consumes = "multipart/form-data")
   @Operation(summary = "게시물 수정", description = "게시물 수정 메서드입니다.")
   public ResponseEntity<ResultResponse> updateBoard(
       @PathVariable Long boardId,

--- a/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
@@ -29,9 +29,6 @@ import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.Link;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -234,20 +231,28 @@ public class BoardController {
         !authorizationHeader.isEmpty()
             && currentLoginUserNickname.equals(userService.getUserByNickname(nickname));
 
-    Page<Board> boardPage = isAuthenticated
-        ? boardService.findBoardByUserNicknameExceptHide(nickname, PageRequest.of(page, size))
-        : boardService.findBoardByUserNickname(nickname, PageRequest.of(page, size));
+    Page<Board> boardPage =
+        isAuthenticated
+            ? boardService.findBoardByUserNicknameExceptHide(nickname, PageRequest.of(page, size))
+            : boardService.findBoardByUserNickname(nickname, PageRequest.of(page, size));
 
-    List<EntityModel<BoardResponse>> boardLists = boardPage.getContent().stream()
-        .map(board -> {
-          Link selfLink = isAuthenticated
-              ? linkTo(methodOn(BoardController.class).findBoardByIdExceptHide(board.getId(), nickname)).withSelfRel()
-              : linkTo(methodOn(BoardController.class).findBoardById(board.getId())).withSelfRel();
-          BoardResponse boardResponse = boardMapper.toDto(board);
-          boardResponse.setAuth(isAuthenticated);
-          return EntityModel.of(boardResponse, selfLink);
-        })
-        .collect(Collectors.toList());
+    List<EntityModel<BoardResponse>> boardLists =
+        boardPage.getContent().stream()
+            .map(
+                board -> {
+                  Link selfLink =
+                      isAuthenticated
+                          ? linkTo(
+                                  methodOn(BoardController.class)
+                                      .findBoardByIdExceptHide(board.getId(), nickname))
+                              .withSelfRel()
+                          : linkTo(methodOn(BoardController.class).findBoardById(board.getId()))
+                              .withSelfRel();
+                  BoardResponse boardResponse = boardMapper.toDto(board);
+                  boardResponse.setAuth(isAuthenticated);
+                  return EntityModel.of(boardResponse, selfLink);
+                })
+            .collect(Collectors.toList());
 
     Pagination<EntityModel<BoardResponse>> result =
         new Pagination<>(

--- a/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
@@ -44,13 +44,13 @@ public class BoardController {
   private final S3Manager s3Manager;
   private final JwtProvider jwtProvider;
   private final UserService userService;
-  
+
   @GetMapping("/{board_id}")
   @Operation(summary = "개별 게시물 출력", description = "개별 게시물 출력 메서드입니다.")
   public ResponseEntity<EntityModel<ResultResponse<Board>>> findBoardById(
       @PathVariable Long board_id,
       @RequestHeader(value = "Authorization", required = false, defaultValue = "")
-      String authorizationHeader) {
+          String authorizationHeader) {
 
     Long currentLoginUserId = userService.getCurrentLoginUser(authorizationHeader);
     boolean isAuthenticated =
@@ -65,11 +65,12 @@ public class BoardController {
       board = boardService.findBoardById(board_id);
     }
     ResultResponse<Board> responseFormat = new ResultResponse<>(BOARD_FIND_SUCCESS, board);
-    Link selfLink = linkTo(methodOn(BoardController.class).findBoardById(board_id, authorizationHeader)).withSelfRel();
+    Link selfLink =
+        linkTo(methodOn(BoardController.class).findBoardById(board_id, authorizationHeader))
+            .withSelfRel();
 
     return ResponseEntity.status(HttpStatus.OK).body(EntityModel.of(responseFormat, selfLink));
   }
-
 
   @PutMapping("/update/{boardId}")
   @Operation(summary = "게시물 수정", description = "게시물 수정 메서드입니다.")
@@ -97,20 +98,23 @@ public class BoardController {
   public ResponseEntity<ResultResponse<List<EntityModel<BoardResponse>>>> findBoardByKeyword(
       @RequestParam("search") String search,
       @RequestHeader(value = "Authorization", required = false, defaultValue = "")
-      String authorizationHeader) {
+          String authorizationHeader) {
     List<EntityModel<BoardResponse>> boards =
         boardService.findBoardByKeyword(search).stream()
             .map(
                 board ->
                     EntityModel.of(
                         board,
-                        linkTo(methodOn(BoardController.class).findBoardById(board.getId(), authorizationHeader))
+                        linkTo(
+                                methodOn(BoardController.class)
+                                    .findBoardById(board.getId(), authorizationHeader))
                             .withSelfRel()))
             .collect(Collectors.toList());
     ResultResponse<List<EntityModel<BoardResponse>>> resultResponse =
         new ResultResponse<>(BOARD_FIND_SUCCESS, boards);
     resultResponse.add(
-        linkTo(methodOn(BoardController.class).findBoardByKeyword(search, authorizationHeader)).withSelfRel());
+        linkTo(methodOn(BoardController.class).findBoardByKeyword(search, authorizationHeader))
+            .withSelfRel());
     return ResponseEntity.status(HttpStatus.OK).body(resultResponse);
   }
 
@@ -158,9 +162,10 @@ public class BoardController {
   @GetMapping("/lists")
   @Operation(summary = "전체 게시물 출력", description = "전체 게시물 출력 메서드입니다.")
   public ResponseEntity<ResultResponse<Pagination<EntityModel<BoardResponse>>>> findAllBoard(
-      @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "30") int size,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "30") int size,
       @RequestHeader(value = "Authorization", required = false, defaultValue = "")
-      String authorizationHeader) {
+          String authorizationHeader) {
     Page<Board> boardPage = boardService.findAllBoard(PageRequest.of(page, size));
     List<EntityModel<BoardResponse>> boardLists =
         boardPage.getContent().stream()
@@ -168,7 +173,9 @@ public class BoardController {
                 board ->
                     EntityModel.of(
                         boardMapper.toDto(board),
-                        linkTo(methodOn(BoardController.class).findBoardById(board.getId(), authorizationHeader))
+                        linkTo(
+                                methodOn(BoardController.class)
+                                    .findBoardById(board.getId(), authorizationHeader))
                             .withSelfRel()))
             .collect(Collectors.toList());
 
@@ -179,7 +186,8 @@ public class BoardController {
             boardPage.getSize(),
             boardPage.getTotalElements(),
             boardPage.getTotalPages(),
-            linkTo(methodOn(BoardController.class).findAllBoard(page, size, authorizationHeader)).withSelfRel());
+            linkTo(methodOn(BoardController.class).findAllBoard(page, size, authorizationHeader))
+                .withSelfRel());
 
     ResultResponse<Pagination<EntityModel<BoardResponse>>> resultResponse =
         new ResultResponse<>(BOARD_FINDALL_SUCCESS, result);
@@ -193,7 +201,7 @@ public class BoardController {
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "30") int size,
       @RequestHeader(value = "Authorization", required = false, defaultValue = "")
-      String authorizationHeader) {
+          String authorizationHeader) {
     Category category1 = Category.valueOf(category.toUpperCase());
     Page<Board> boardPage = boardService.findBoardByCategory(category1, PageRequest.of(page, size));
     List<EntityModel<BoardResponse>> boardLists =
@@ -202,7 +210,9 @@ public class BoardController {
                 board ->
                     EntityModel.of(
                         boardMapper.toDto(board),
-                        linkTo(methodOn(BoardController.class).findBoardById(board.getId(), authorizationHeader))
+                        linkTo(
+                                methodOn(BoardController.class)
+                                    .findBoardById(board.getId(), authorizationHeader))
                             .withSelfRel()))
             .collect(Collectors.toList());
 
@@ -213,7 +223,9 @@ public class BoardController {
             boardPage.getSize(),
             boardPage.getTotalElements(),
             boardPage.getTotalPages(),
-            linkTo(methodOn(BoardController.class).findBoardByCategory(category, page, size, authorizationHeader))
+            linkTo(
+                    methodOn(BoardController.class)
+                        .findBoardByCategory(category, page, size, authorizationHeader))
                 .withSelfRel());
 
     ResultResponse<Pagination<EntityModel<BoardResponse>>> resultResponse =
@@ -252,7 +264,9 @@ public class BoardController {
                                   methodOn(BoardController.class)
                                       .findBoardById(board.getId(), nickname))
                               .withSelfRel()
-                          : linkTo(methodOn(BoardController.class).findBoardById(board.getId(), authorizationHeader))
+                          : linkTo(
+                                  methodOn(BoardController.class)
+                                      .findBoardById(board.getId(), authorizationHeader))
                               .withSelfRel();
                   BoardResponse boardResponse = boardMapper.toDto(board);
                   boardResponse.setAuth(isAuthenticated);

--- a/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
@@ -277,14 +277,14 @@ public class BoardController {
     }
     else {
       Page<Board> boardPage =
-          boardService.findBoardByUserNickname(nickname, PageRequest.of(page, size));
+          boardService.findBoardByUserNicknameExceptHide(nickname, PageRequest.of(page, size));
       List<EntityModel<BoardResponse>> boardLists =
           boardPage.getContent().stream()
               .map(
                   board ->
                       EntityModel.of(
                           boardMapper.toDto(board),
-                          linkTo(methodOn(BoardController.class).findBoardById(board.getId()))
+                          linkTo(methodOn(BoardController.class).findBoardByIdExceptHide(board.getId(), nickname))
                               .withSelfRel()))
               .collect(Collectors.toList());
 

--- a/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
@@ -63,6 +63,18 @@ public class BoardController {
                 responseFormat,
                 linkTo(methodOn(BoardController.class).findBoardById(board_id)).withSelfRel()));
   }
+  @GetMapping("/{nickname}/{board_id}")
+  public ResponseEntity<EntityModel<ResultResponse<Board>>> findBoardByIdExceptHide(
+      @PathVariable Long board_id,
+      @PathVariable String nickname) {
+    BoardResponse board = boardService.findBoardByIdExceptHide(board_id);
+    ResultResponse<Board> responseFormat = new ResultResponse<>(BOARD_FIND_SUCCESS, board);
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(
+            EntityModel.of(
+                responseFormat,
+                linkTo(methodOn(BoardController.class).findBoardByIdExceptHide(board_id, nickname)).withSelfRel()));
+  }
 
   @PutMapping("/update/{boardId}")
   @Operation(summary = "게시물 수정", description = "게시물 수정 메서드입니다.")

--- a/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
@@ -83,7 +83,7 @@ public class BoardController {
       @RequestParam Category category2,
       @RequestParam MultipartFile thumbnailFile,
       @RequestHeader(value = "Authorization", required = false, defaultValue = "")
-      String authorizationHeader) {
+          String authorizationHeader) {
     Long currentLoginUserId = userService.getCurrentLoginUser(authorizationHeader);
     boolean isAuthenticated =
         !authorizationHeader.isEmpty()
@@ -91,26 +91,33 @@ public class BoardController {
 
     if (isAuthenticated) {
       UploadFileResponse updateFiles = boardService.updateFiles(thumbnailFile);
-      BoardUpdateRequest boardUpdateRequest = BoardUpdateRequest.builder()
-          .title(title)
-          .content(content)
-          .category1(category1)
-          .category2(category2)
-          .thumbnail_url(updateFiles.getThumbnail_url())
-          .build();
+      BoardUpdateRequest boardUpdateRequest =
+          BoardUpdateRequest.builder()
+              .title(title)
+              .content(content)
+              .category1(category1)
+              .category2(category2)
+              .thumbnail_url(updateFiles.getThumbnail_url())
+              .build();
       boardService.updateBoard(boardId, boardUpdateRequest);
       ResultResponse<Board> resultResponse = new ResultResponse<>(BOARD_UPDATED_SUCCESS);
       resultResponse.add(
           linkTo(
-              methodOn(BoardController.class)
-                  .updateBoard(boardId, title, content, category1, category2, thumbnailFile, authorizationHeader))
+                  methodOn(BoardController.class)
+                      .updateBoard(
+                          boardId,
+                          title,
+                          content,
+                          category1,
+                          category2,
+                          thumbnailFile,
+                          authorizationHeader))
               .withSelfRel());
       return ResponseEntity.status(HttpStatus.OK).body(resultResponse);
     } else {
       throw new NoAuthority();
     }
   }
-
 
   @DeleteMapping("/{boardId}")
   @Operation(summary = "게시물 삭제", description = "게시물 삭제 메서드입니다.")

--- a/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
@@ -250,7 +250,7 @@ public class BoardController {
     }
     Pagination<EntityModel<BoardResponse>> result = null;
 
-    if("".equals(authorizationHeader) || currentLoginUserNickname.equals(userService.getUserByNickname(nickname))) {
+    if("".equals(authorizationHeader) || !currentLoginUserNickname.equals(userService.getUserByNickname(nickname))) {
       Page<Board> boardPage =
           boardService.findBoardByUserNickname(nickname, PageRequest.of(page, size));
       List<EntityModel<BoardResponse>> boardLists =

--- a/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
@@ -77,27 +77,40 @@ public class BoardController {
   @Operation(summary = "게시물 수정", description = "게시물 수정 메서드입니다.")
   public ResponseEntity<ResultResponse> updateBoard(
       @PathVariable Long boardId,
-      @RequestBody BoardUpdateRequest boardUpdateRequest,
+      @RequestParam String title,
+      @RequestParam String content,
+      @RequestParam Category category1,
+      @RequestParam Category category2,
+      @RequestParam MultipartFile thumbnailFile,
       @RequestHeader(value = "Authorization", required = false, defaultValue = "")
-          String authorizationHeader) {
+      String authorizationHeader) {
     Long currentLoginUserId = userService.getCurrentLoginUser(authorizationHeader);
     boolean isAuthenticated =
         !authorizationHeader.isEmpty()
             && currentLoginUserId.equals(userService.getUserIdByBoardId(boardId));
 
     if (isAuthenticated) {
+      UploadFileResponse updateFiles = boardService.updateFiles(thumbnailFile);
+      BoardUpdateRequest boardUpdateRequest = BoardUpdateRequest.builder()
+          .title(title)
+          .content(content)
+          .category1(category1)
+          .category2(category2)
+          .thumbnail_url(updateFiles.getThumbnail_url())
+          .build();
       boardService.updateBoard(boardId, boardUpdateRequest);
       ResultResponse<Board> resultResponse = new ResultResponse<>(BOARD_UPDATED_SUCCESS);
       resultResponse.add(
           linkTo(
-                  methodOn(BoardController.class)
-                      .updateBoard(boardId, boardUpdateRequest, authorizationHeader))
+              methodOn(BoardController.class)
+                  .updateBoard(boardId, title, content, category1, category2, thumbnailFile, authorizationHeader))
               .withSelfRel());
       return ResponseEntity.status(HttpStatus.OK).body(resultResponse);
     } else {
       throw new NoAuthority();
     }
   }
+
 
   @DeleteMapping("/{boardId}")
   @Operation(summary = "게시물 삭제", description = "게시물 삭제 메서드입니다.")

--- a/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
@@ -76,23 +76,25 @@ public class BoardController {
   @PutMapping("/update/{boardId}")
   @Operation(summary = "게시물 수정", description = "게시물 수정 메서드입니다.")
   public ResponseEntity<ResultResponse> updateBoard(
-      @PathVariable Long boardId, @RequestBody BoardUpdateRequest boardUpdateRequest,
+      @PathVariable Long boardId,
+      @RequestBody BoardUpdateRequest boardUpdateRequest,
       @RequestHeader(value = "Authorization", required = false, defaultValue = "")
-      String authorizationHeader) {
+          String authorizationHeader) {
     Long currentLoginUserId = userService.getCurrentLoginUser(authorizationHeader);
     boolean isAuthenticated =
         !authorizationHeader.isEmpty()
             && currentLoginUserId.equals(userService.getUserIdByBoardId(boardId));
 
-    if(isAuthenticated) {
+    if (isAuthenticated) {
       boardService.updateBoard(boardId, boardUpdateRequest);
       ResultResponse<Board> resultResponse = new ResultResponse<>(BOARD_UPDATED_SUCCESS);
       resultResponse.add(
-          linkTo(methodOn(BoardController.class).updateBoard(boardId, boardUpdateRequest, authorizationHeader))
+          linkTo(
+                  methodOn(BoardController.class)
+                      .updateBoard(boardId, boardUpdateRequest, authorizationHeader))
               .withSelfRel());
       return ResponseEntity.status(HttpStatus.OK).body(resultResponse);
-    }
-    else {
+    } else {
       throw new NoAuthority();
     }
   }

--- a/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
@@ -21,8 +21,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.swing.text.html.parser.Entity;
-import javax.xml.transform.Result;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -246,87 +244,110 @@ public class BoardController {
     }
     Page<Board> boardPage;
 
-    boolean isAuthenticated = !authorizationHeader.isEmpty() && currentLoginUserNickname.equals(userService.getUserByNickname(nickname));
+    boolean isAuthenticated =
+        !authorizationHeader.isEmpty()
+            && currentLoginUserNickname.equals(userService.getUserByNickname(nickname));
 
-    if(isAuthenticated) {
-      boardPage = boardService.findBoardByUserNicknameExceptHide(nickname, PageRequest.of(page, size));
-    }
-    else {
+    if (isAuthenticated) {
+      boardPage =
+          boardService.findBoardByUserNicknameExceptHide(nickname, PageRequest.of(page, size));
+    } else {
       boardPage = boardService.findBoardByUserNickname(nickname, PageRequest.of(page, size));
     }
 
-    List<EntityModel<BoardResponse>> boardLists = boardPage.getContent().stream()
-        .map(board -> EntityModel.of(boardMapper.toDto(board), isAuthenticated ?
-            linkTo(methodOn(BoardController.class).findBoardByIdExceptHide(board.getId(), nickname)).withSelfRel() :
-            linkTo(methodOn(BoardController.class).findBoardById(board.getId())).withSelfRel()))
-        .collect(Collectors.toList());
+    List<EntityModel<BoardResponse>> boardLists =
+        boardPage.getContent().stream()
+            .map(
+                board ->
+                    EntityModel.of(
+                        boardMapper.toDto(board),
+                        isAuthenticated
+                            ? linkTo(
+                                    methodOn(BoardController.class)
+                                        .findBoardByIdExceptHide(board.getId(), nickname))
+                                .withSelfRel()
+                            : linkTo(methodOn(BoardController.class).findBoardById(board.getId()))
+                                .withSelfRel()))
+            .collect(Collectors.toList());
 
-    Pagination<EntityModel<BoardResponse>> result = new Pagination<>(boardLists, boardPage.getNumber(), boardPage.getSize(), boardPage.getTotalElements(), boardPage.getTotalPages(), linkTo(methodOn(BoardController.class).findBoardByUserId(nickname, page, size, authorizationHeader)).withSelfRel());
+    Pagination<EntityModel<BoardResponse>> result =
+        new Pagination<>(
+            boardLists,
+            boardPage.getNumber(),
+            boardPage.getSize(),
+            boardPage.getTotalElements(),
+            boardPage.getTotalPages(),
+            linkTo(
+                    methodOn(BoardController.class)
+                        .findBoardByUserId(nickname, page, size, authorizationHeader))
+                .withSelfRel());
 
-    ResultResponse<Pagination<EntityModel<BoardResponse>>> resultResponse = new ResultResponse<>(BOARD_FINDALL_SUCCESS, result);
+    ResultResponse<Pagination<EntityModel<BoardResponse>>> resultResponse =
+        new ResultResponse<>(BOARD_FINDALL_SUCCESS, result);
 
     return ResponseEntity.ok().body(resultResponse);
 
-//    if ("".equals(authorizationHeader)
-//        || !currentLoginUserNickname.equals(userService.getUserByNickname(nickname))) {
-//      Page<Board> boardPage =
-//          boardService.findBoardByUserNickname(nickname, PageRequest.of(page, size));
-//      List<EntityModel<BoardResponse>> boardLists =
-//          boardPage.getContent().stream()
-//              .map(
-//                  board ->
-//                      EntityModel.of(
-//                          boardMapper.toDto(board),
-//                          linkTo(methodOn(BoardController.class).findBoardById(board.getId()))
-//                              .withSelfRel()))
-//              .collect(Collectors.toList());
-//
-//      Pagination<EntityModel<BoardResponse>> resultNoAuth =
-//          new Pagination<>(
-//              boardLists,
-//              boardPage.getNumber(),
-//              boardPage.getSize(),
-//              boardPage.getTotalElements(),
-//              boardPage.getTotalPages(),
-//              linkTo(
-//                      methodOn(BoardController.class)
-//                          .findBoardByUserId(nickname, page, size, authorizationHeader))
-//                  .withSelfRel());
-//
-//      result = resultNoAuth;
-//    } else {
-//      Page<Board> boardPage =
-//          boardService.findBoardByUserNicknameExceptHide(nickname, PageRequest.of(page, size));
-//      List<EntityModel<BoardResponse>> boardLists =
-//          boardPage.getContent().stream()
-//              .map(
-//                  board ->
-//                      EntityModel.of(
-//                          boardMapper.toDto(board),
-//                          linkTo(
-//                                  methodOn(BoardController.class)
-//                                      .findBoardByIdExceptHide(board.getId(), nickname))
-//                              .withSelfRel()))
-//              .collect(Collectors.toList());
-//
-//      Pagination<EntityModel<BoardResponse>> resultAuth =
-//          new Pagination<>(
-//              boardLists,
-//              boardPage.getNumber(),
-//              boardPage.getSize(),
-//              boardPage.getTotalElements(),
-//              boardPage.getTotalPages(),
-//              linkTo(
-//                      methodOn(BoardController.class)
-//                          .findBoardByUserId(nickname, page, size, authorizationHeader))
-//                  .withSelfRel());
-//
-//      result = resultAuth;
-//    }
-//
-//    ResultResponse<Pagination<EntityModel<BoardResponse>>> resultResponse =
-//        new ResultResponse<>(BOARD_FINDALL_SUCCESS, result);
-//    return ResponseEntity.ok().body(resultResponse);
+    //    if ("".equals(authorizationHeader)
+    //        || !currentLoginUserNickname.equals(userService.getUserByNickname(nickname))) {
+    //      Page<Board> boardPage =
+    //          boardService.findBoardByUserNickname(nickname, PageRequest.of(page, size));
+    //      List<EntityModel<BoardResponse>> boardLists =
+    //          boardPage.getContent().stream()
+    //              .map(
+    //                  board ->
+    //                      EntityModel.of(
+    //                          boardMapper.toDto(board),
+    //                          linkTo(methodOn(BoardController.class).findBoardById(board.getId()))
+    //                              .withSelfRel()))
+    //              .collect(Collectors.toList());
+    //
+    //      Pagination<EntityModel<BoardResponse>> resultNoAuth =
+    //          new Pagination<>(
+    //              boardLists,
+    //              boardPage.getNumber(),
+    //              boardPage.getSize(),
+    //              boardPage.getTotalElements(),
+    //              boardPage.getTotalPages(),
+    //              linkTo(
+    //                      methodOn(BoardController.class)
+    //                          .findBoardByUserId(nickname, page, size, authorizationHeader))
+    //                  .withSelfRel());
+    //
+    //      result = resultNoAuth;
+    //    } else {
+    //      Page<Board> boardPage =
+    //          boardService.findBoardByUserNicknameExceptHide(nickname, PageRequest.of(page,
+    // size));
+    //      List<EntityModel<BoardResponse>> boardLists =
+    //          boardPage.getContent().stream()
+    //              .map(
+    //                  board ->
+    //                      EntityModel.of(
+    //                          boardMapper.toDto(board),
+    //                          linkTo(
+    //                                  methodOn(BoardController.class)
+    //                                      .findBoardByIdExceptHide(board.getId(), nickname))
+    //                              .withSelfRel()))
+    //              .collect(Collectors.toList());
+    //
+    //      Pagination<EntityModel<BoardResponse>> resultAuth =
+    //          new Pagination<>(
+    //              boardLists,
+    //              boardPage.getNumber(),
+    //              boardPage.getSize(),
+    //              boardPage.getTotalElements(),
+    //              boardPage.getTotalPages(),
+    //              linkTo(
+    //                      methodOn(BoardController.class)
+    //                          .findBoardByUserId(nickname, page, size, authorizationHeader))
+    //                  .withSelfRel());
+    //
+    //      result = resultAuth;
+    //    }
+    //
+    //    ResultResponse<Pagination<EntityModel<BoardResponse>>> resultResponse =
+    //        new ResultResponse<>(BOARD_FINDALL_SUCCESS, result);
+    //    return ResponseEntity.ok().body(resultResponse);
   }
 
   @PostMapping(value = "/files", consumes = "multipart/form-data")

--- a/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
@@ -227,21 +227,7 @@ public class BoardController {
       @RequestHeader(value = "Authorization", required = false, defaultValue = "")
           String authorizationHeader) {
 
-    Long currentLoginUserNickname = null;
-
-    if (!authorizationHeader.isEmpty()) {
-      String accessToken = authorizationHeader.substring(7); // "Bearer " 이후의 값만 추출
-
-      // 토큰이 유효한지 검증
-      if (!jwtProvider.validateToken(accessToken)) {
-        throw new RuntimeException("유효하지 않은 토큰입니다.");
-      }
-
-      // 현재 로그인한 사용자 정보 가져오기
-      Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-      UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-      currentLoginUserNickname = Long.valueOf(userDetails.getUsername());
-    }
+    Long currentLoginUserNickname = userService.getCurrentLoginUser(authorizationHeader);
     Page<Board> boardPage;
 
     boolean isAuthenticated =
@@ -286,68 +272,6 @@ public class BoardController {
         new ResultResponse<>(BOARD_FINDALL_SUCCESS, result);
 
     return ResponseEntity.ok().body(resultResponse);
-
-    //    if ("".equals(authorizationHeader)
-    //        || !currentLoginUserNickname.equals(userService.getUserByNickname(nickname))) {
-    //      Page<Board> boardPage =
-    //          boardService.findBoardByUserNickname(nickname, PageRequest.of(page, size));
-    //      List<EntityModel<BoardResponse>> boardLists =
-    //          boardPage.getContent().stream()
-    //              .map(
-    //                  board ->
-    //                      EntityModel.of(
-    //                          boardMapper.toDto(board),
-    //                          linkTo(methodOn(BoardController.class).findBoardById(board.getId()))
-    //                              .withSelfRel()))
-    //              .collect(Collectors.toList());
-    //
-    //      Pagination<EntityModel<BoardResponse>> resultNoAuth =
-    //          new Pagination<>(
-    //              boardLists,
-    //              boardPage.getNumber(),
-    //              boardPage.getSize(),
-    //              boardPage.getTotalElements(),
-    //              boardPage.getTotalPages(),
-    //              linkTo(
-    //                      methodOn(BoardController.class)
-    //                          .findBoardByUserId(nickname, page, size, authorizationHeader))
-    //                  .withSelfRel());
-    //
-    //      result = resultNoAuth;
-    //    } else {
-    //      Page<Board> boardPage =
-    //          boardService.findBoardByUserNicknameExceptHide(nickname, PageRequest.of(page,
-    // size));
-    //      List<EntityModel<BoardResponse>> boardLists =
-    //          boardPage.getContent().stream()
-    //              .map(
-    //                  board ->
-    //                      EntityModel.of(
-    //                          boardMapper.toDto(board),
-    //                          linkTo(
-    //                                  methodOn(BoardController.class)
-    //                                      .findBoardByIdExceptHide(board.getId(), nickname))
-    //                              .withSelfRel()))
-    //              .collect(Collectors.toList());
-    //
-    //      Pagination<EntityModel<BoardResponse>> resultAuth =
-    //          new Pagination<>(
-    //              boardLists,
-    //              boardPage.getNumber(),
-    //              boardPage.getSize(),
-    //              boardPage.getTotalElements(),
-    //              boardPage.getTotalPages(),
-    //              linkTo(
-    //                      methodOn(BoardController.class)
-    //                          .findBoardByUserId(nickname, page, size, authorizationHeader))
-    //                  .withSelfRel());
-    //
-    //      result = resultAuth;
-    //    }
-    //
-    //    ResultResponse<Pagination<EntityModel<BoardResponse>>> resultResponse =
-    //        new ResultResponse<>(BOARD_FINDALL_SUCCESS, result);
-    //    return ResponseEntity.ok().body(resultResponse);
   }
 
   @PostMapping(value = "/files", consumes = "multipart/form-data")

--- a/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/controller/BoardController.java
@@ -59,17 +59,18 @@ public class BoardController {
                 responseFormat,
                 linkTo(methodOn(BoardController.class).findBoardById(board_id)).withSelfRel()));
   }
+
   @GetMapping("/{nickname}/{board_id}")
   public ResponseEntity<EntityModel<ResultResponse<Board>>> findBoardByIdExceptHide(
-      @PathVariable Long board_id,
-      @PathVariable String nickname) {
+      @PathVariable Long board_id, @PathVariable String nickname) {
     BoardResponse board = boardService.findBoardByIdExceptHide(board_id);
     ResultResponse<Board> responseFormat = new ResultResponse<>(BOARD_FIND_SUCCESS, board);
     return ResponseEntity.status(HttpStatus.OK)
         .body(
             EntityModel.of(
                 responseFormat,
-                linkTo(methodOn(BoardController.class).findBoardByIdExceptHide(board_id, nickname)).withSelfRel()));
+                linkTo(methodOn(BoardController.class).findBoardByIdExceptHide(board_id, nickname))
+                    .withSelfRel()));
   }
 
   @PutMapping("/update/{boardId}")
@@ -246,7 +247,8 @@ public class BoardController {
     }
     Pagination<EntityModel<BoardResponse>> result = null;
 
-    if("".equals(authorizationHeader) || !currentLoginUserNickname.equals(userService.getUserByNickname(nickname))) {
+    if ("".equals(authorizationHeader)
+        || !currentLoginUserNickname.equals(userService.getUserByNickname(nickname))) {
       Page<Board> boardPage =
           boardService.findBoardByUserNickname(nickname, PageRequest.of(page, size));
       List<EntityModel<BoardResponse>> boardLists =
@@ -281,7 +283,9 @@ public class BoardController {
                   board ->
                       EntityModel.of(
                           boardMapper.toDto(board),
-                          linkTo(methodOn(BoardController.class).findBoardByIdExceptHide(board.getId(), nickname))
+                          linkTo(
+                                  methodOn(BoardController.class)
+                                      .findBoardByIdExceptHide(board.getId(), nickname))
                               .withSelfRel()))
               .collect(Collectors.toList());
 

--- a/src/main/java/com/techeer/port/voilio/domain/board/dto/request/BoardUpdateRequest.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/dto/request/BoardUpdateRequest.java
@@ -5,9 +5,11 @@ import com.techeer.port.voilio.global.common.Category;
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
 import org.hibernate.validator.constraints.URL;
 
+@Builder
 @Getter
 public class BoardUpdateRequest {
   @NotBlank private String title;

--- a/src/main/java/com/techeer/port/voilio/domain/board/dto/response/BoardResponse.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/dto/response/BoardResponse.java
@@ -22,5 +22,6 @@ public class BoardResponse {
   private LocalDateTime created_at;
   private Long user_id;
   private String nickname;
+  private boolean isPublic;
   @Setter private boolean auth;
 }

--- a/src/main/java/com/techeer/port/voilio/domain/board/dto/response/BoardResponse.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/dto/response/BoardResponse.java
@@ -9,7 +9,6 @@ import lombok.ToString;
 
 @Builder
 @Getter
-@Setter
 @ToString
 public class BoardResponse {
   private Long id;
@@ -23,5 +22,6 @@ public class BoardResponse {
   private LocalDateTime created_at;
   private Long user_id;
   private String nickname;
+  @Setter
   private boolean auth;
 }

--- a/src/main/java/com/techeer/port/voilio/domain/board/dto/response/BoardResponse.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/dto/response/BoardResponse.java
@@ -4,10 +4,12 @@ import com.techeer.port.voilio.global.common.Category;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 @Builder
 @Getter
+@Setter
 @ToString
 public class BoardResponse {
   private Long id;
@@ -21,4 +23,5 @@ public class BoardResponse {
   private LocalDateTime created_at;
   private Long user_id;
   private String nickname;
+  private boolean auth;
 }

--- a/src/main/java/com/techeer/port/voilio/domain/board/dto/response/BoardResponse.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/dto/response/BoardResponse.java
@@ -22,6 +22,5 @@ public class BoardResponse {
   private LocalDateTime created_at;
   private Long user_id;
   private String nickname;
-  @Setter
-  private boolean auth;
+  @Setter private boolean auth;
 }

--- a/src/main/java/com/techeer/port/voilio/domain/board/dto/response/UpdateFileResponse.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/dto/response/UpdateFileResponse.java
@@ -1,0 +1,10 @@
+package com.techeer.port.voilio.domain.board.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class UpdateFileResponse {
+    private String thumbnail_url;
+}

--- a/src/main/java/com/techeer/port/voilio/domain/board/dto/response/UpdateFileResponse.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/dto/response/UpdateFileResponse.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 @Builder
 @Getter
 public class UpdateFileResponse {
-    private String thumbnail_url;
+  private String thumbnail_url;
 }

--- a/src/main/java/com/techeer/port/voilio/domain/board/exception/NoAuthority.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/exception/NoAuthority.java
@@ -4,8 +4,7 @@ import com.techeer.port.voilio.global.error.ErrorCode;
 import com.techeer.port.voilio.global.error.exception.BusinessException;
 
 public class NoAuthority extends BusinessException {
-    public NoAuthority() {
-        super(ErrorCode.NO_AUTHORITY);
-    }
-
+  public NoAuthority() {
+    super(ErrorCode.NO_AUTHORITY);
+  }
 }

--- a/src/main/java/com/techeer/port/voilio/domain/board/exception/NoAuthority.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/exception/NoAuthority.java
@@ -1,0 +1,11 @@
+package com.techeer.port.voilio.domain.board.exception;
+
+import com.techeer.port.voilio.global.error.ErrorCode;
+import com.techeer.port.voilio.global.error.exception.BusinessException;
+
+public class NoAuthority extends BusinessException {
+    public NoAuthority() {
+        super(ErrorCode.NO_AUTHORITY);
+    }
+
+}

--- a/src/main/java/com/techeer/port/voilio/domain/board/mapper/BoardMapper.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/mapper/BoardMapper.java
@@ -33,4 +33,8 @@ public class BoardMapper {
   public UploadFileResponse toDto(String videoUrl, String thumbnailUrl) {
     return UploadFileResponse.builder().video_url(videoUrl).thumbnail_url(thumbnailUrl).build();
   }
+
+  public UploadFileResponse toDto(String thumbnailUrl) {
+    return UploadFileResponse.builder().thumbnail_url(thumbnailUrl).build();
+  }
 }

--- a/src/main/java/com/techeer/port/voilio/domain/board/mapper/BoardMapper.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/mapper/BoardMapper.java
@@ -22,6 +22,7 @@ public class BoardMapper {
         .created_at(board.getCreateAt())
         .user_id(board.getUser().getId())
         .nickname(board.getUser().getNickname())
+        .isPublic(board.isPublic())
         .build();
   }
 

--- a/src/main/java/com/techeer/port/voilio/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/repository/BoardRepository.java
@@ -24,6 +24,10 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
   Optional<Board> findBoardById(@Param("board_id") Long id);
 
   @Query(
+      "SELECT b FROM Board b WHERE b.id = :board_id AND b.isDeleted = false")
+  Optional<Board> findBoardByIdExceptHide(@Param("board_id") Long id);
+
+  @Query(
       "SELECT b FROM Board b WHERE b.isDeleted is false AND b.isPublic is true ORDER BY"
           + " b.createAt DESC")
   Page<Board> findAllBoard(Pageable pageable);
@@ -40,4 +44,9 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
       "SELECT b FROM Board b WHERE b.isDeleted = false AND b.isPublic = true AND b.user.nickname ="
           + " :nickname ORDER BY b.createAt DESC")
   Page<Board> findBoardByUserNickname(@Param("nickname") String nickname, Pageable pageable);
+
+  @Query(
+      "SELECT b FROM Board b WHERE b.isDeleted = false AND b.user.nickname ="
+          + " :nickname ORDER BY b.createAt DESC")
+  Page<Board> findBoardByUserNicknameExceptHide(@Param("nickname") String nickname, Pageable pageable);
 }

--- a/src/main/java/com/techeer/port/voilio/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/repository/BoardRepository.java
@@ -23,8 +23,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
       "SELECT b FROM Board b WHERE b.id = :board_id AND b.isDeleted = false AND b.isPublic = true")
   Optional<Board> findBoardById(@Param("board_id") Long id);
 
-  @Query(
-      "SELECT b FROM Board b WHERE b.id = :board_id AND b.isDeleted = false")
+  @Query("SELECT b FROM Board b WHERE b.id = :board_id AND b.isDeleted = false")
   Optional<Board> findBoardByIdExceptHide(@Param("board_id") Long id);
 
   @Query(
@@ -48,5 +47,6 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
   @Query(
       "SELECT b FROM Board b WHERE b.isDeleted = false AND b.user.nickname ="
           + " :nickname ORDER BY b.createAt DESC")
-  Page<Board> findBoardByUserNicknameExceptHide(@Param("nickname") String nickname, Pageable pageable);
+  Page<Board> findBoardByUserNicknameExceptHide(
+      @Param("nickname") String nickname, Pageable pageable);
 }

--- a/src/main/java/com/techeer/port/voilio/domain/board/service/BoardService.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/service/BoardService.java
@@ -15,6 +15,7 @@ import com.techeer.port.voilio.global.common.Category;
 import com.techeer.port.voilio.s3.util.S3Manager;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import net.minidev.asm.ex.ConvertException;
 import org.springframework.data.domain.Page;
@@ -87,7 +88,7 @@ public class BoardService {
   }
 
   public Page<Board> findBoardByUserNickname(String nickname, Pageable pageable) {
-    User user = userRepository.findUserByNickname(nickname);
+    Optional<User> user = userRepository.findUserByNickname(nickname);
     Page<Board> result = boardRepository.findBoardByUserNickname(nickname, pageable);
 
     if (result.isEmpty()) {

--- a/src/main/java/com/techeer/port/voilio/domain/board/service/BoardService.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/service/BoardService.java
@@ -45,6 +45,11 @@ public class BoardService {
     return boardMapper.toDto(board);
   }
 
+  public BoardResponse findBoardByIdExceptHide(Long board_id) {
+    Board board = boardRepository.findBoardByIdExceptHide(board_id).orElseThrow(NotFoundBoard::new);
+    return boardMapper.toDto(board);
+  }
+
   @Transactional
   public void createBoard(BoardCreateRequest boardCreateRequest) {
     User user =
@@ -90,6 +95,17 @@ public class BoardService {
   public Page<Board> findBoardByUserNickname(String nickname, Pageable pageable) {
     Optional<User> user = userRepository.findUserByNickname(nickname);
     Page<Board> result = boardRepository.findBoardByUserNickname(nickname, pageable);
+
+    if (result.isEmpty()) {
+      if (user == null) throw new NotFoundUser();
+      else throw new NotFoundBoard();
+    }
+    return result;
+  }
+
+  public Page<Board> findBoardByUserNicknameExceptHide(String nickname, Pageable pageable) {
+    Optional<User> user = userRepository.findUserByNickname(nickname);
+    Page<Board> result = boardRepository.findBoardByUserNicknameExceptHide(nickname, pageable);
 
     if (result.isEmpty()) {
       if (user == null) throw new NotFoundUser();

--- a/src/main/java/com/techeer/port/voilio/domain/board/service/BoardService.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/service/BoardService.java
@@ -122,4 +122,13 @@ public class BoardService {
       throw new ConvertException();
     }
   }
+
+  public UploadFileResponse updateFiles(MultipartFile thumbnailFile) {
+    try {
+      return boardMapper.toDto(
+          s3Manager.upload(thumbnailFile, "thumbnail"));
+    } catch (IOException e) {
+      throw new ConvertException();
+    }
+  }
 }

--- a/src/main/java/com/techeer/port/voilio/domain/board/service/BoardService.java
+++ b/src/main/java/com/techeer/port/voilio/domain/board/service/BoardService.java
@@ -125,8 +125,7 @@ public class BoardService {
 
   public UploadFileResponse updateFiles(MultipartFile thumbnailFile) {
     try {
-      return boardMapper.toDto(
-          s3Manager.upload(thumbnailFile, "thumbnail"));
+      return boardMapper.toDto(s3Manager.upload(thumbnailFile, "thumbnail"));
     } catch (IOException e) {
       throw new ConvertException();
     }

--- a/src/main/java/com/techeer/port/voilio/domain/user/controller/UserController.java
+++ b/src/main/java/com/techeer/port/voilio/domain/user/controller/UserController.java
@@ -63,6 +63,16 @@ public class UserController {
     return ResponseEntity.status(HttpStatus.OK).body(resultResponse);
   }
 
+  @GetMapping("/nickname/{nickname}")
+  @Operation(summary = "회원 조회2", description = "지정 회원을 조회하는 메서드입니다.")
+  public ResponseEntity<ResultResponse> getUserByNickname(@PathVariable("nickname") String nickname) {
+    User user = userService.getUser(nickname);
+    ResultResponse<User> resultResponse = new ResultResponse<>(GET_USER_SUCCESS, user);
+    resultResponse.add(linkTo(methodOn(UserController.class).getUserByNickname(nickname)).withSelfRel());
+
+    return ResponseEntity.status(HttpStatus.OK).body(resultResponse);
+  }
+
   @DeleteMapping("/{user_id}")
   @Operation(summary = "회원 삭제", description = "회원 삭제 메서드입니다.")
   public ResponseEntity<ResultResponse> deleteUser(@PathVariable("user_id") Long userId) {

--- a/src/main/java/com/techeer/port/voilio/domain/user/controller/UserController.java
+++ b/src/main/java/com/techeer/port/voilio/domain/user/controller/UserController.java
@@ -65,10 +65,12 @@ public class UserController {
 
   @GetMapping("/nickname/{nickname}")
   @Operation(summary = "회원 조회2", description = "지정 회원을 조회하는 메서드입니다.")
-  public ResponseEntity<ResultResponse> getUserByNickname(@PathVariable("nickname") String nickname) {
+  public ResponseEntity<ResultResponse> getUserByNickname(
+      @PathVariable("nickname") String nickname) {
     User user = userService.getUser(nickname);
     ResultResponse<User> resultResponse = new ResultResponse<>(GET_USER_SUCCESS, user);
-    resultResponse.add(linkTo(methodOn(UserController.class).getUserByNickname(nickname)).withSelfRel());
+    resultResponse.add(
+        linkTo(methodOn(UserController.class).getUserByNickname(nickname)).withSelfRel());
 
     return ResponseEntity.status(HttpStatus.OK).body(resultResponse);
   }

--- a/src/main/java/com/techeer/port/voilio/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/techeer/port/voilio/domain/user/repository/UserRepository.java
@@ -20,4 +20,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   @Query("SELECT u FROM User u WHERE u.nickname = :nickname and u.isDeleted=false ")
   Optional<User> findUserByNickname(@Param("nickname") String nickname);
+
+  @Query("SELECT b.user.id FROM Board b WHERE b.id = :boardId")
+  Long findUserIdByBoardId(@Param("boardId") Long boardId);
 }

--- a/src/main/java/com/techeer/port/voilio/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/techeer/port/voilio/domain/user/repository/UserRepository.java
@@ -19,5 +19,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
   boolean existsByEmail(String email);
 
   @Query("SELECT u FROM User u WHERE u.nickname = :nickname and u.isDeleted=false ")
-  User findUserByNickname(@Param("nickname") String nickname);
+  Optional<User> findUserByNickname(@Param("nickname") String nickname);
 }

--- a/src/main/java/com/techeer/port/voilio/domain/user/service/UserService.java
+++ b/src/main/java/com/techeer/port/voilio/domain/user/service/UserService.java
@@ -35,8 +35,8 @@ public class UserService {
     return user;
   }
 
-  public User getUser(String email) {
-    User user = userRepository.findUserByEmail(email).orElseThrow(NotFoundUser::new);
+  public User getUser(String nickname) {
+    User user = userRepository.findUserByNickname(nickname).orElseThrow(NotFoundUser::new);
     return user;
   }
 

--- a/src/main/java/com/techeer/port/voilio/domain/user/service/UserService.java
+++ b/src/main/java/com/techeer/port/voilio/domain/user/service/UserService.java
@@ -61,10 +61,10 @@ public class UserService {
   public Long getCurrentLoginUser(String authorizationHeader) {
     Long currentLoginUserNickname = null;
 
-    if(!authorizationHeader.isEmpty()) {
+    if (!authorizationHeader.isEmpty()) {
       String accessToken = authorizationHeader.substring(7);
 
-      if(!jwtProvider.validateToken(accessToken)) {
+      if (!jwtProvider.validateToken(accessToken)) {
         throw new RuntimeException("유호하지 않은 토큰입니다.");
       }
 

--- a/src/main/java/com/techeer/port/voilio/domain/user/service/UserService.java
+++ b/src/main/java/com/techeer/port/voilio/domain/user/service/UserService.java
@@ -45,6 +45,12 @@ public class UserService {
     return user.getId();
   }
 
+  public Long getUserIdByBoardId(Long board_id) {
+    Long id = userRepository.findUserIdByBoardId(board_id);
+
+    return id;
+  }
+
   public void deleteUser(Long userId) {
     User user = getUser(userId);
     user.changeDeleted();

--- a/src/main/java/com/techeer/port/voilio/domain/user/service/UserService.java
+++ b/src/main/java/com/techeer/port/voilio/domain/user/service/UserService.java
@@ -10,6 +10,9 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,5 +56,22 @@ public class UserService {
         .findById(SecurityUtil.getCurrentMemberId())
         .map(UserResponse::of)
         .orElseThrow(() -> new RuntimeException("로그인 유저 정보가 없습니다"));
+  }
+
+  public Long getCurrentLoginUser(String authorizationHeader) {
+    Long currentLoginUserNickname = null;
+
+    if(!authorizationHeader.isEmpty()) {
+      String accessToken = authorizationHeader.substring(7);
+
+      if(!jwtProvider.validateToken(accessToken)) {
+        throw new RuntimeException("유호하지 않은 토큰입니다.");
+      }
+
+      Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+      UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+      currentLoginUserNickname = Long.valueOf(userDetails.getUsername());
+    }
+    return currentLoginUserNickname;
   }
 }

--- a/src/main/java/com/techeer/port/voilio/domain/user/service/UserService.java
+++ b/src/main/java/com/techeer/port/voilio/domain/user/service/UserService.java
@@ -36,6 +36,10 @@ public class UserService {
     User user = userRepository.findUserByEmail(email).orElseThrow(NotFoundUser::new);
     return user;
   }
+  public Long getUserByNickname(String nickname) {
+    User user = userRepository.findUserByNickname(nickname).orElseThrow(NotFoundUser::new);
+    return user.getId();
+  }
 
   public void deleteUser(Long userId) {
     User user = getUser(userId);

--- a/src/main/java/com/techeer/port/voilio/global/config/WebConfig.java
+++ b/src/main/java/com/techeer/port/voilio/global/config/WebConfig.java
@@ -10,10 +10,11 @@ public class WebConfig implements WebMvcConfigurer {
 
   @Override
   public void addCorsMappings(final CorsRegistry registry) {
-    registry.addMapping("/**")
-            .allowedOrigins("http://localhost:3000", "http://www.voilio.site")
-            .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
-            .allowedHeaders("*")
-            .allowCredentials(true);
+    registry
+        .addMapping("/**")
+        .allowedOrigins("http://localhost:3000", "http://www.voilio.site")
+        .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
+        .allowedHeaders("*")
+        .allowCredentials(true);
   }
 }

--- a/src/main/java/com/techeer/port/voilio/global/error/ErrorCode.java
+++ b/src/main/java/com/techeer/port/voilio/global/error/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode {
   ALREADY_EXIST_USER(400, "U004", "이미 가입된 유저 email 입니다."),
   INVAILD_USER_INFO(401, "U005", "가입되지 않은 유저거나, 이메일과 비밀번호가 일치하지 않습니다."),
 
+  NO_AUTHORITY(401, "U006", "권한이 없습니다."),
+
   // board
   BOARD_NOT_FOUND_ERROR(400, "B001", "게시글을 찾을 수 없음"),
   // comment


### PR DESCRIPTION
## 추가/수정한 기능 설명
유저 별 게시물 출력 API
�만약 로그인한 유저가 자신의 게시물을 볼때는 public = false 여도 다 볼 수 있어야하고,
아닌 경우에는 public = true인 게시물만 볼 수 있게 한다.

개별 게시물 출력 API
로그인 한 유저가 게시물을 생성한 유저와 동일하다면 auth : true 를 반환하게 해야한다.
그렇지 않다면 auth : false 를 반환하게 해야한다

게시물 수정 API
로그인 한 유저가 수정하려는 게시물을 생성한 유저와 동일하다면 수정API에 접근이 가능해야한다.
그렇지 않다면 접근이 불가능해야한다.

회원 조회 API
닉네임으로 조회할 수 있는 API 하나 더 생성해야한다.
<br>


## check list
- [x] issue number를 브랜치 앞에 추가 하였는가?
- [x] 추가/수정사항을 설명하였는가?