### PR TITLE
Fix: Dto의 빌더패턴 삭제에 따른 로직 수정

### DIFF
--- a/src/main/java/com/techeer/port/voilio/domain/user/controller/AuthController.java
+++ b/src/main/java/com/techeer/port/voilio/domain/user/controller/AuthController.java
@@ -5,7 +5,6 @@ import static com.techeer.port.voilio.global.result.ResultCode.USER_REGISTRATION
 
 import com.techeer.port.voilio.domain.user.dto.request.UserLoginRequest;
 import com.techeer.port.voilio.domain.user.dto.request.UserSignUpRequest;
-import com.techeer.port.voilio.domain.user.dto.response.UserResponse;
 import com.techeer.port.voilio.domain.user.service.AuthService;
 import com.techeer.port.voilio.global.config.security.TokenDto;
 import com.techeer.port.voilio.global.result.ResultResponse;
@@ -26,14 +25,10 @@ public class AuthController {
   private final AuthService authService;
 
   @PostMapping("/signup")
-  public ResponseEntity<ResultResponse<UserResponse>> signup(
-      @RequestBody UserSignUpRequest userSignUpRequest) throws AlreadyBoundException {
-    UserResponse userResponse = authService.signup(userSignUpRequest);
-    ResultResponse<UserResponse> resultResponse =
-        new ResultResponse<>(USER_REGISTRATION_SUCCESS, userResponse);
-    //    resultResponse.add(
-    //        linkTo(methodOn(AuthController.class).signup(userSignUpRequest)).withSelfRel());
-
+  public ResponseEntity<ResultResponse<Boolean>> signup(
+      @RequestBody UserSignUpRequest userSignUpRequest) {
+    Boolean isSignup =  authService.signup(userSignUpRequest);
+    ResultResponse<Boolean> resultResponse = new ResultResponse<>(USER_REGISTRATION_SUCCESS, isSignup);
     return ResponseEntity.status(HttpStatus.OK).body(resultResponse);
   }
 

--- a/src/main/java/com/techeer/port/voilio/domain/user/controller/AuthController.java
+++ b/src/main/java/com/techeer/port/voilio/domain/user/controller/AuthController.java
@@ -27,8 +27,9 @@ public class AuthController {
   @PostMapping("/signup")
   public ResponseEntity<ResultResponse<Boolean>> signup(
       @RequestBody UserSignUpRequest userSignUpRequest) {
-    Boolean isSignup =  authService.signup(userSignUpRequest);
-    ResultResponse<Boolean> resultResponse = new ResultResponse<>(USER_REGISTRATION_SUCCESS, isSignup);
+    Boolean isSignup = authService.signup(userSignUpRequest);
+    ResultResponse<Boolean> resultResponse =
+        new ResultResponse<>(USER_REGISTRATION_SUCCESS, isSignup);
     return ResponseEntity.status(HttpStatus.OK).body(resultResponse);
   }
 

--- a/src/main/java/com/techeer/port/voilio/domain/user/dto/request/UserSignUpRequest.java
+++ b/src/main/java/com/techeer/port/voilio/domain/user/dto/request/UserSignUpRequest.java
@@ -1,32 +1,12 @@
 package com.techeer.port.voilio.domain.user.dto.request;
 
-import com.techeer.port.voilio.domain.user.entity.Authority;
-import com.techeer.port.voilio.domain.user.entity.User;
-import com.techeer.port.voilio.global.common.YnType;
-import java.time.LocalDateTime;
 import lombok.*;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
+@Setter
 public class UserSignUpRequest {
-  private Long id;
+
   private String email;
   private String password;
   private String nickname;
-  private LocalDateTime activatedAt;
-
-  public User toEntity(PasswordEncoder passwordEncoder) {
-    return User.builder()
-        .id(id)
-        .email(email)
-        .password(passwordEncoder.encode(password))
-        .nickname(nickname)
-        .activatedAt(LocalDateTime.now())
-        .authority(Authority.ROLE_USER)
-        .delYn(YnType.valueOf("N"))
-        .build();
-  }
 }

--- a/src/main/java/com/techeer/port/voilio/domain/user/entity/User.java
+++ b/src/main/java/com/techeer/port/voilio/domain/user/entity/User.java
@@ -92,13 +92,19 @@ public class User extends BaseEntity implements UserDetails {
     this.changeIsStopped(YnType.Y);
   }
 
-  public void changePassword(String password) {this.password = password;}
+  public void changePassword(String password) {
+    this.password = password;
+  }
 
-  public void changeUserRole(Authority roleType) {this.authority = roleType;}
+  public void changeUserRole(Authority roleType) {
+    this.authority = roleType;
+  }
 
-  public void changeDelYn(YnType ynType) {this.delYn = ynType;}
+  public void changeDelYn(YnType ynType) {
+    this.delYn = ynType;
+  }
 
-  public void changeIsStopped(YnType ynType) {this.isStopped = ynType;}
-
-
+  public void changeIsStopped(YnType ynType) {
+    this.isStopped = ynType;
+  }
 }

--- a/src/main/java/com/techeer/port/voilio/domain/user/entity/User.java
+++ b/src/main/java/com/techeer/port/voilio/domain/user/entity/User.java
@@ -39,6 +39,7 @@ public class User extends BaseEntity implements UserDetails {
   private LocalDateTime activatedAt;
 
   @Column(name = "is_stopped")
+  @Enumerated(EnumType.STRING)
   private YnType isStopped;
 
   @OneToMany(
@@ -51,6 +52,7 @@ public class User extends BaseEntity implements UserDetails {
   @Enumerated(EnumType.STRING)
   private Authority authority;
 
+  @Column(name = "del_yn")
   @Enumerated(EnumType.STRING)
   private YnType delYn;
 

--- a/src/main/java/com/techeer/port/voilio/domain/user/entity/User.java
+++ b/src/main/java/com/techeer/port/voilio/domain/user/entity/User.java
@@ -88,15 +88,17 @@ public class User extends BaseEntity implements UserDetails {
     this.activatedAt = activatedAt;
   }
 
-  public void setStopped(YnType stopped) {
-    isStopped = stopped;
-  }
-
   public void changeSleeperUser() {
-    this.setStopped(YnType.Y);
+    this.changeIsStopped(YnType.Y);
   }
 
-  public void changeDelYn(YnType delYn) {
-    this.delYn = delYn;
-  }
+  public void changePassword(String password) {this.password = password;}
+
+  public void changeUserRole(Authority roleType) {this.authority = roleType;}
+
+  public void changeDelYn(YnType ynType) {this.delYn = ynType;}
+
+  public void changeIsStopped(YnType ynType) {this.isStopped = ynType;}
+
+
 }

--- a/src/main/java/com/techeer/port/voilio/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/techeer/port/voilio/domain/user/mapper/UserMapper.java
@@ -20,7 +20,7 @@ public interface UserMapper {
 
   User toEntity(UserDto userDto);
 
-  User toEntity(UserSignUpRequest userSignUpRequest, PasswordEncoder passwordEncoder);
+  User toEntity(UserSignUpRequest userSignUpRequest);
 
   List<UserResponse> toDtos(List<User> users);
 }

--- a/src/main/java/com/techeer/port/voilio/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/techeer/port/voilio/domain/user/mapper/UserMapper.java
@@ -7,7 +7,6 @@ import com.techeer.port.voilio.domain.user.entity.User;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Mapper
 public interface UserMapper {

--- a/src/main/java/com/techeer/port/voilio/domain/user/service/AuthService.java
+++ b/src/main/java/com/techeer/port/voilio/domain/user/service/AuthService.java
@@ -12,10 +12,9 @@ import com.techeer.port.voilio.domain.user.repository.UserRepository;
 import com.techeer.port.voilio.global.common.YnType;
 import com.techeer.port.voilio.global.config.security.JwtProvider;
 import com.techeer.port.voilio.global.config.security.TokenDto;
-import java.time.LocalDateTime;
-
 import com.techeer.port.voilio.global.error.ErrorCode;
 import com.techeer.port.voilio.global.error.exception.BusinessException;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -33,13 +32,12 @@ public class AuthService {
   private final PasswordEncoder passwordEncoder;
   private final JwtProvider jwtProvider;
 
-
   @Transactional
   public Boolean signup(UserSignUpRequest userSignUpRequest) {
     if (userRepository.existsByEmail(userSignUpRequest.getEmail())) {
       throw new AlreadyExistUser();
     }
-    try{
+    try {
       User user = UserMapper.INSTANCE.toEntity(userSignUpRequest);
       user.changePassword(passwordEncoder.encode(userSignUpRequest.getPassword()));
       user.changeUserRole(Authority.ROLE_USER);
@@ -47,7 +45,7 @@ public class AuthService {
       user.changeIsStopped(YnType.N);
       userRepository.save(user);
       return true;
-    } catch (Exception e){
+    } catch (Exception e) {
       throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
     }
   }


### PR DESCRIPTION
## 추가/수정한 기능 설명

1. UserSignUpRequest 의 빌더패턴 삭제
2. UserSignUpRequest 의 id 필드 삭제
3. 빌더패턴 삭제에 따른 Mapper 이용
4. signUp service return 값을 boolean 으로 설정
5. 사용자 정보를 저장하므로 service 로직에 Transaction 추가
6. Custom Error 템플릿 적극 사용


## check list
- [X] issue number를 브랜치 앞에 추가 하였는가?
- [X] 추가/수정사항을 설명하였는가?